### PR TITLE
sdf: change the naming scheme

### DIFF
--- a/ruby/lib/transformer/sdf.rb
+++ b/ruby/lib/transformer/sdf.rb
@@ -20,13 +20,13 @@ module Transformer
             end
             if sdf.respond_to?(:each_model)
                 sdf.each_model do |m|
-                    frames m.full_name
+                    frames m.name
 
                     if m.parent.name
                         if m.static?
-                            static_transform(*m.pose, m.full_name => m.parent.full_name)
+                            static_transform(*m.pose, m.name => m.parent.full_name)
                         else
-                            example_transform(*m.pose, m.full_name => m.parent.full_name)
+                            example_transform(*m.pose, m.name => m.parent.full_name)
                         end
                     end
 
@@ -50,10 +50,10 @@ module Transformer
                     child2parent = parent2model.inverse * child2model
                     joint2parent = child2parent * joint2child
 
-                    parent = parent.full_name
-                    child  = child.full_name
-                    joint_pre  = "#{j.full_name}_pre"
-                    joint_post = "#{j.full_name}_post"
+                    parent = "#{sdf.name}::#{parent.name}"
+                    child  = "#{sdf.name}::#{child.name}"
+                    joint_pre  = "#{sdf.name}::#{j.name}_pre"
+                    joint_post = "#{sdf.name}::#{j.name}_post"
                     register_joint(joint_post, joint_pre, j)
                     static_transform(joint2child, joint_post => child)
                     static_transform(joint2parent, joint_pre => parent)
@@ -76,7 +76,7 @@ module Transformer
                 end
 
                 root_links.each_value do |l|
-                    static_transform(*l.pose, l.full_name => l.parent.full_name)
+                    static_transform(*l.pose, "#{sdf.name}::#{l.name}" => sdf.name)
                 end
             end
         end

--- a/ruby/test/test_sdf.rb
+++ b/ruby/test/test_sdf.rb
@@ -23,13 +23,13 @@ module Transformer
 
         it "prefixes frames hierarchically" do
             conf.load_sdf('model://model_within_a_world')
-            assert_equal %w{world_name world_name::root_model_name},
+            assert_equal %w{root_model_name world_name},
                 conf.frames.to_a.sort
         end
 
         it "creates a static transform between root links and the model" do
             conf.load_sdf('model://model_with_only_root_links')
-            tr = conf.transformation_for('w::m::root_link', 'w::m')
+            tr = conf.transformation_for('m::root_link', 'm')
             assert Eigen::Vector3.new(1, 2, 3).
                 approx?(tr.translation)
             assert Eigen::Quaternion.from_angle_axis(2, Eigen::Vector3.UnitZ).
@@ -38,7 +38,7 @@ module Transformer
 
         it "creates static transforms between the links and the joints" do
             conf.load_sdf('model://model_with_child_links')
-            tr = conf.transformation_for('w::m::j_post', 'w::m::child_link')
+            tr = conf.transformation_for('m::j_post', 'm::child_link')
             assert Eigen::Vector3.new(1, 2, 3).
                 approx?(tr.translation)
             assert Eigen::Quaternion.from_angle_axis(2, Eigen::Vector3.UnitZ).
@@ -52,13 +52,13 @@ module Transformer
                 recorder.call(joint.full_name)
                 'producer'
             end
-            tr = conf.transformation_for('w::m::j_post', 'w::m::j_pre')
+            tr = conf.transformation_for('m::j_post', 'm::j_pre')
             assert 'producer', tr.producer
         end
 
         it "always creates example transformations between root links and child links using the axis limits" do
             conf.load_sdf('model://model_with_child_links')
-            tr = conf.example_transformation_for('w::m::j_post', 'w::m::j_pre')
+            tr = conf.example_transformation_for('m::j_post', 'm::j_pre')
             assert_equal Eigen::Vector3.Zero, tr.translation
             assert Eigen::Quaternion.from_angle_axis(1.5, Eigen::Vector3.UnitX).approx?(tr.rotation)
         end


### PR DESCRIPTION
The world name is not prefixed before the model names anymore. There
is a lot of thinking going into this, but mainly:
- there can be only one world
- the model names have to be unique within one world (so we don't
  need to prefix with the world name to make the model name unique)

However, joints are links are still prefixed by the model name, since
the same robot present multiple times in the same world would differ
only from their model names.
