### PR TITLE
syskit: fix propagation of frame selection after 402d0d8b6

### DIFF
--- a/ruby/lib/transformer/syskit/frame_propagation.rb
+++ b/ruby/lib/transformer/syskit/frame_propagation.rb
@@ -418,18 +418,17 @@ module Transformer
                 end
             end
 
-            if new_selections.empty?
-                if current_selection.empty?
-                    debug { "no frames selected for #{task}" }
-                    task.select_frames(static_frames)
-                else
+            result =
+                if new_selections.empty?
                     debug { "selecting frame mappings #{current_selection} on #{task}, propagated from its parents" }
-                    task.select_frames(current_selection.merge(static_frames))
+                    current_selection
+                else
+                    debug { "adding frame selection from #{task}: #{new_selections}" }
+                    new_selections
                 end
-            else
-                debug { "adding frame selection from #{task}: #{new_selections}" }
-                task.select_frames(new_selections.merge(static_frames))
-            end
+            result = result.merge(static_frames)
+            task.select_frames(result)
+            result
         end
 
         def self.initialize_transform_producers(task, current_selection)

--- a/ruby/lib/transformer/syskit/plugin.rb
+++ b/ruby/lib/transformer/syskit/plugin.rb
@@ -239,10 +239,12 @@ module Transformer
         end
 
         def self.propagate_local_transformer_configuration(root_task)
-            FramePropagation.initialize_selected_frames(root_task, Hash.new)
+            selected_frames = Hash.new
+            selected_frames[root_task] = FramePropagation.initialize_selected_frames(root_task, Hash.new)
             FramePropagation.initialize_transform_producers(root_task, Transformer::Configuration.new)
             Roby::TaskStructure::Hierarchy.each_bfs(root_task, BGL::Graph::ALL) do |from, to, info|
-                FramePropagation.initialize_selected_frames(to, from.selected_frames)
+                selected_frames[to] = FramePropagation.initialize_selected_frames(
+                    to, selected_frames[from])
                 FramePropagation.initialize_transform_producers(to, from.transformer)
             end
         end


### PR DESCRIPTION
The propagation through the hierarchy was done through
task.selected_frames (which, in hindsight, is stupid). Since
task.selected_frames now only contains the frames that are of
importance for 'task', that does not work anymore
