### PR TITLE
syskit: adapt to the addition of #associate_ports_to_transform

### DIFF
--- a/ruby/lib/transformer/syskit/extensions/component.rb
+++ b/ruby/lib/transformer/syskit/extensions/component.rb
@@ -49,13 +49,11 @@ module Transformer
         # The frame names are actual frame names, not task-local ones
         def find_transformation_input(from, to)
             return if !(tr = model.transformer)
-            tr.each_transform_port do |port, transform|
-                if port.kind_of?(Orocos::Spec::InputPort)
-                    port_from = selected_frames[transform.from]
-                    port_to   = selected_frames[transform.to]
-                    if port_from == from && port_to == to
-                        return port
-                    end
+            tr.each_transform_input do |port, transform|
+                port_from = selected_frames[transform.from]
+                port_to   = selected_frames[transform.to]
+                if port_from == from && port_to == to
+                    return port
                 end
             end
             nil

--- a/ruby/lib/transformer/syskit/frame_propagation.rb
+++ b/ruby/lib/transformer/syskit/frame_propagation.rb
@@ -203,15 +203,7 @@ module Transformer
                     done_port_info(task, port.name)
                 end
             end
-            tr.each_transform_output do |port, transform|
-                from = task.selected_frames[transform.from]
-                to   = task.selected_frames[transform.to]
-                add_port_info(task, port.name, TransformAnnotation.new(task, transform.from, from, transform.to, to))
-                if from && to
-                    done_port_info(task, port.name)
-                end
-            end
-            tr.each_transform_input do |port, transform|
+            tr.each_transform_port do |port, transform|
                 from = task.selected_frames[transform.from]
                 to   = task.selected_frames[transform.to]
                 add_port_info(task, port.name, TransformAnnotation.new(task, transform.from, from, transform.to, to))

--- a/ruby/lib/transformer/syskit/plugin.rb
+++ b/ruby/lib/transformer/syskit/plugin.rb
@@ -21,8 +21,8 @@ module Transformer
                 # Register transformation producers that are connected to
                 # some of our transformation input ports
                 self_producers = Hash.new
-                tr.each_transform_port do |port, transform|
-                    if port.kind_of?(Orocos::Spec::InputPort) && task.connected?(port.name)
+                tr.each_transform_input do |port, transform|
+                    if task.connected?(port.name)
                         port_from = task.selected_frames[transform.from]
                         port_to   = task.selected_frames[transform.to]
                         if port_from && port_to
@@ -192,9 +192,7 @@ module Transformer
                         Transformer.warn "no frame selected for #{frame_name} on #{task}. This is harmless for the network to run, but will make the display of #{port.name} \"in the right frame\" impossible"
                     end
                 end
-                tr.each_transform_port do |port, transform|
-                    next if port.kind_of?(Orocos::Spec::InputPort)
-
+                tr.each_transform_output do |port, transform|
                     from = task.selected_frames[transform.from]
                     to   = task.selected_frames[transform.to]
                     if from && to


### PR DESCRIPTION
Depends on https://github.com/Brazilian-Institute-of-Robotics/bir.flat_fish.br-buildconf/pull/16 
https://github.com/rock-core/drivers-orogen-transformer/pull/11

This declaration is a weaker version of #transform_input.
transform_input declares that a port inputs a certain frame _and_
that this transform is fed manually to the transformer. The new
predicate only declares the association. All transform_input/
transform_output ports have their association declared automatically.
.
each_transform_port now enumerates all associations (instead of
only the transform_input/transform_output ports), as it was its
actual intended use in most cases. Replace the few places where
the intended use was to enumerate the transform input/output by
the correct enumerator (interestingly, they were doing class-based
tests for inputs or outputs, so the change ends up being a cleanup
as well)
