### PR TITLE
syskit: import the transformer info first in use_profile

### DIFF
--- a/ruby/lib/transformer/syskit/extensions/profile.rb
+++ b/ruby/lib/transformer/syskit/extensions/profile.rb
@@ -65,11 +65,10 @@ module Transformer
         end
 
         def use_profile(profile, tags = Hash.new, transform_names: ->(name) { name })
-            new_definitions = super
             if profile.has_transformer?
                 use_profile_transformer(profile, tags)
             end
-            new_definitions
+            super
         end
 
         # Called by Profile to modify an instance requirement object w.r.t. the


### PR DESCRIPTION
The info can be relevant when promoting requirements from the used
profile, so we must make sure it has been integrated first.